### PR TITLE
optimize getDevice, getDevices

### DIFF
--- a/local/core/client.go
+++ b/local/core/client.go
@@ -102,6 +102,10 @@ func (c *Client) getDeviceConfiguration() deviceConfiguration {
 	}
 }
 
+func (c *Client) GetDiscoveryConfiguration() DiscoveryConfiguration {
+	return c.discoveryConfiguration
+}
+
 func NewClient(opts ...OptionFunc) *Client {
 	cfg := config{
 		errFunc: func(err error) {

--- a/local/core/getDevices.go
+++ b/local/core/getDevices.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/plgd-dev/go-coap/v2/udp/client"
+	"github.com/plgd-dev/kit/net/coap"
 	"github.com/plgd-dev/sdk/schema"
 )
 
@@ -25,7 +26,8 @@ func (c *Client) GetDevices(ctx context.Context, handler DeviceHandler) error {
 			conn.Close()
 		}
 	}()
-	return DiscoverDevices(ctx, multicastConn, newDiscoveryHandler(c.getDeviceConfiguration(), handler))
+	// we want to just get "oic.wk.d" resource, because links will be get via unicast to /oic/res
+	return DiscoverDevices(ctx, multicastConn, newDiscoveryHandler(c.getDeviceConfiguration(), handler), coap.WithResourceType("oic.wk.d"))
 }
 
 func newDiscoveryHandler(


### PR DESCRIPTION
we want to just get "oic.wk.d" link, because other links will be get via unicast to /oic/res

blockwise transfer cost lot's of cpu/memory and so we just filter oic.wk.d to avoid use it for multicast message