### PR TITLE
fill endpoints from the device when a resource doesn't contain any

### DIFF
--- a/local/core/device.go
+++ b/local/core/device.go
@@ -199,7 +199,7 @@ func (d *Device) connectToEndpoint(ctx context.Context, endpoint schema.Endpoint
 	return addr, c, nil
 }
 
-func (d *Device) connectToEndpoints(ctx context.Context, endpoints []schema.Endpoint) (net.Addr, *coap.ClientCloseHandler, error) {
+func (d *Device) connectToEndpoints(ctx context.Context, endpoints schema.Endpoints) (net.Addr, *coap.ClientCloseHandler, error) {
 	errors := make([]error, 0, 4)
 
 	for _, endpoint := range endpoints {

--- a/local/core/discoverDevices.go
+++ b/local/core/discoverDevices.go
@@ -60,7 +60,7 @@ func handleResponse(ctx context.Context, handler DiscoverDevicesHandler) func(*c
 			handler.Error(fmt.Errorf("invalid address %v: %w", cc.RemoteAddr(), err))
 			return
 		}
-		links = links.PatchEndpoint(addr)
+		links = links.PatchEndpoint(addr, nil)
 		if len(links) > 0 {
 			handler.Handle(ctx, cc, links)
 		}

--- a/local/core/getResourceLinks.go
+++ b/local/core/getResourceLinks.go
@@ -10,7 +10,7 @@ import (
 	"github.com/plgd-dev/sdk/schema"
 )
 
-func getResourceLinks(ctx context.Context, addr net.Addr, client *coap.ClientCloseHandler, options ...coap.OptionFunc) (schema.ResourceLinks, error) {
+func getResourceLinks(ctx context.Context, addr net.Addr, client *coap.ClientCloseHandler, deviceEndpoints schema.Endpoints, options ...coap.OptionFunc) (schema.ResourceLinks, error) {
 	options = append(options, coap.WithAccept(message.AppOcfCbor))
 	var links schema.ResourceLinks
 
@@ -20,7 +20,7 @@ func getResourceLinks(ctx context.Context, addr net.Addr, client *coap.ClientClo
 	if err != nil {
 		return nil, err
 	}
-	return links.PatchEndpoint(addr), nil
+	return links.PatchEndpoint(addr, deviceEndpoints), nil
 }
 
 func (d *Device) GetResourceLinks(ctx context.Context, endpoints []schema.Endpoint, options ...coap.OptionFunc) (schema.ResourceLinks, error) {
@@ -28,7 +28,7 @@ func (d *Device) GetResourceLinks(ctx context.Context, endpoints []schema.Endpoi
 	if err != nil {
 		return nil, MakeDataLoss(fmt.Errorf("cannot get resource links for %v with endpoints %+v: %w", d.DeviceID(), endpoints, err))
 	}
-	links, err := getResourceLinks(ctx, addr, client, options...)
+	links, err := getResourceLinks(ctx, addr, client, d.GetEndpoints(), options...)
 	if err != nil {
 		return links, MakeDataLoss(fmt.Errorf("cannot get resource links for %v: %w", d.DeviceID(), err))
 	}

--- a/local/core/ownDevice.go
+++ b/local/core/ownDevice.go
@@ -396,7 +396,7 @@ func (d *Device) Own(
 		return MakeInternal(fmt.Errorf("cannot set device to provision operation mode: %w", err))
 	}
 
-	links, err = getResourceLinks(ctx, tlsAddr, tlsClient)
+	links, err = getResourceLinks(ctx, tlsAddr, tlsClient, d.GetEndpoints())
 	if err != nil {
 		if errDisown := disown(ctx, tlsClient); errDisown != nil {
 			d.cfg.errFunc(fmt.Errorf("cannot disown device: %w", errDisown))


### PR DESCRIPTION
When the device running in docker, sometimes it cannot fill endpoints for links,
because packet at device comes from loopback interface instead of docker_gwbridge.
And the loopback is not used for generating endpoints.
It seems like a BUG in the kernel (4.4.0-210-generic) with docker/bridge interfaces.